### PR TITLE
better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Outscale SAS <opensource@outscale.com>"]
 edition = "2021"
 license = "BSD-3-Clause"
 description = "Outscale API SDK"
-homepage = "https://github.com/outscale/osc-sdk-rust/"
+repository = "https://github.com/outscale/osc-sdk-rust/"
 
 [dependencies]
 home = "0.5.3"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it
See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field)
